### PR TITLE
默认开启 Sentry 上报错误

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ ENV BUILD_PACKAGES="build-base libxml2 libxslt libxslt imagemagick tzdata git" \
     ORIGINAL_REPO_URL="http://dl-cdn.alpinelinux.org" \
     MIRROR_REPO_URL="https://mirrors.tuna.tsinghua.edu.cn" \
     NPM_REGISTRY="https://registry.npm.taobao.org" \
+    ZEALOT_VERSION="$VERSION" \
+    ZEALOT_VCS_REF="$VCS_REF" \
     TZ="Asia/Shanghai" \
     RAILS_ENV="production"
 

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem 'whenever', '~> 1.0.0', require: false
 gem 'sys-filesystem', '~> 1.3.2'
 gem 'vmstat', '~> 2.3.0'
 
+# 异常报错上报
+gem "sentry-raven"
+
 # Jenkins SDK
 gem 'jenkins_api_client'
 # 生成条形码/二维码

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,8 @@ GEM
       rubyzip (>= 1.1.6)
     rubyntlm (0.6.2)
     rubyzip (2.0.0)
+    sentry-raven (2.13.0)
+      faraday (>= 0.7.6, < 1.0)
     settingslogic (2.0.9)
     shellany (0.0.1)
     sidekiq (6.0.4)
@@ -482,6 +484,7 @@ DEPENDENCIES
   rqrcode
   rubocop (~> 0.77)
   ruby-debug-ide
+  sentry-raven
   settingslogic
   sidekiq (<= 7)
   simple_form (~> 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :set_raven_context
+
   include Pundit
 
   # Prevent CSRF attacks by raising an exception.
@@ -13,6 +15,11 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   private
+
+  def set_raven_context
+    Raven.user_context(id: session[:current_user_id])
+    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
+  end
 
   def user_not_authorized
     flash[:warning] = '没有权限进行本次操作。'

--- a/app/jobs/sentry_job.rb
+++ b/app/jobs/sentry_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SentryJob < ApplicationJob
+  queue_as :default
+
+  def perform(event)
+    Raven.send_event(event)
+  end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# 默认开启 Sentry，如果不想使用设置 ZEALOT_SENTRY_DISABLE=1
+if ENV['ZEALOT_SENTRY_DISABLE'].blank?
+  Raven.configure do |config|
+    config.dsn = ENV['ZEALOT_SENTRY_DNS'] || 'https://133aefa9f52448a1a7900ba9d02f93e1@sentry.io/1878137'
+    config.excluded_exceptions += ['ActionController::RoutingError', 'ActiveRecord::RecordNotFound']
+    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+    config.sanitize_fields << 'token'
+    config.async = -> (event) { SentryJob.perform_later(event) }
+
+    version = ENV['ZEALOT_VERSION'] || Setting.version
+    vcs_ref = ENV['ZEALOT_VCS_REF']
+    version = "#{version}-#{vcs_ref}" if vcs_ref.present?
+    config.release = version
+
+    tags = {}
+    tags[:docker] = true if vcs_ref.present?
+    config.tags = tags
+  end
+end


### PR DESCRIPTION
匿名收集 Zealot 运行期间发生的错误信息有助于帮助 zealot 更好的发现问题和解决问题。默认上报操作是开启状态，如果需要禁止可通过设置环境变量 `ZEALOT_SENTRY_DISABLE=1` 禁止