### PR TITLE
演示模式

### DIFF
--- a/app/jobs/reset_for_demo_mode_job.rb
+++ b/app/jobs/reset_for_demo_mode_job.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class ResetForDemoModeJob < ApplicationJob
+  queue_as :schedule
+
+  def perform
+    return unless demo_mode?
+
+    clean_apps
+    clean_users
+    init_demo_data
+  end
+
+  private
+
+  def demo_mode?
+    if (value = ENV['ZEALOT_DEMO_MODE']) && value.present?
+      return true if value.to_i == 1
+      return true if value.downcase == 'true'
+    end
+
+    logger.warn("Zealot is not in demo mode, can not execute ResetForDemoModeJob.")
+
+    false
+  end
+
+  def clean_apps
+    apps = App.all
+    apps.each do |app|
+      app.destroy
+    end
+  end
+
+  def clean_users
+    users = User.all
+    users.each do |user|
+      user.destroy
+    end
+  end
+
+  def init_demo_data
+    user = CreateAdminService.new.call
+    CreateSampleAppsService.new.call(user)
+  end
+end

--- a/app/services/create_sample_apps_service.rb
+++ b/app/services/create_sample_apps_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CreateSampleAppsService
+  RELEASE_COUNT = 3
+
   def call(user)
     stardford_app user
     android_channels_app user
@@ -51,7 +53,7 @@ class CreateSampleAppsService
                          'release'
                        end
 
-        100.times do
+        RELEASE_COUNT.times do
           generate_release(channel, bundle_id, release_type, changelog)
         end
       end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+def env_key_enabled?(key)
+  return false unless value = ENV[key]
+  return false if value.blank?
+  return true if value.to_i == 1
+  return true if value.downcase == 'true'
+
+  false
+end
+
 sidekiq_config = { url: ENV['REDIS_URL'] || 'redis://localhost:6379/0' }
 
 Sidekiq.configure_server do |config|
@@ -17,8 +26,14 @@ end
 if Sidekiq.server?
   cron_jobs = Zealot::Setting.cron_jobs
 
-  keep_uploads = ENV['ZEALOT_KEEP_UPLOADS']
-  keep_uploads = keep_uploads.present? && keep_uploads.downcase != 'false'
+  keep_uploads = env_key_enabled?('ZEALOT_KEEP_UPLOADS')
   cron_jobs.delete_if { |k, _| keep_uploads && k == 'clean_old_releases' }
+
+  demo_mode = env_key_enabled?('ZEALOT_DEMO_MODE')
+  cron_jobs.delete_if { |k, _| !demo_mode && k == 'reset_for_demo_mode' }
+
+  # 从 demo mode 禁用后需要删除定时任务
+  Sidekiq::Cron::Job.destroy('reset_for_demo_mode') unless demo_mode
+
   Sidekiq::Cron::Job.load_from_hash cron_jobs
 end

--- a/config/zealot.yml
+++ b/config/zealot.yml
@@ -6,6 +6,10 @@ default: &base
       cron: '0 6 * * *'
       class: 'CleanOldReleasesJob'
       queue: schedule
+    reset_for_demo_mode:
+      cron: '0 0 * * *'
+      class: 'ResetForDemoModeJob'
+      queue: schedule
 
 development:
   <<: *base

--- a/lib/tasks/zealot.rake
+++ b/lib/tasks/zealot.rake
@@ -6,6 +6,11 @@ namespace :zealot do
     Rake::Task['zealot:db:upgrade'].invoke
   end
 
+  desc 'Zealot | Remove all data and init demo data and user'
+  task reset: :environment do
+    ResetForDemoModeJob.perform_now
+  end
+
   namespace :db do
     task upgrade: :environment do
       begin


### PR DESCRIPTION
**演示模式对于使用本项目的用户说是绝对用不到的**，此模式仅用于项目部署演示使用，因为涉及的功能点不多，仅仅实在增加了定时任务每天重新初始化数据来防止被用户长期使用或修改管理员密码等操作。