### PR TITLE
重构 deviecs 数据展示并支持上传同步设备名称

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,9 @@ Metrics/AbcSize:
   Exclude:
     - 'lib/backup/**/*'
 
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
 Style/AsciiComments:
   Enabled: false
 

--- a/Guardfile
+++ b/Guardfile
@@ -44,6 +44,7 @@ end
 # CLI: 'rails server'                  # customizes runner command. Omits all options except `pid_file`!
 guard :rails, host: '0.0.0.0', environment: environment do
   ignore(%r{^config/(locales|webpack)/.*})
+  ignore(%r{^lib/tasks/.*})
 
   watch('.env')
   watch('Gemfile.lock')

--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Api::DevicesController < Api::BaseController
+  before_action :validate_user_token
+  before_action :set_device
+
+  # POST /api/devices/:id?name=MyiPhone
+  def update
+    raise ActiveRecord::RecordNotFound, "设备 UDID (#{params[:id]}) 不存在" unless @device
+    raise ActionController::ParameterMissing, 'name' if device_params[:name].blank?
+
+    @device.update(device_params)
+    render json: @device
+  end
+
+  protected
+
+  def set_device
+    @device = Device.find_by(udid: params[:id])
+  end
+
+  def device_params
+    params.permit(:name)
+  end
+end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Device < ApplicationRecord
+  has_and_belongs_to_many :releases
+end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -9,6 +9,7 @@ class Release < ApplicationRecord
   scope :latest, -> { order(version: :desc).first }
 
   belongs_to :channel
+  has_and_belongs_to_many :devices
 
   validates :bundle_id, :release_version, :build_version, :file, presence: true
   validate :bundle_id_matched, on: :create
@@ -83,7 +84,7 @@ class Release < ApplicationRecord
   def size
     file&.size
   end
-  alias file_size size
+  alias_method :file_size, :size
 
   def short_git_commit
     return nil if git_commit.blank?

--- a/app/views/releases/body/_devices.html.slim
+++ b/app/views/releases/body/_devices.html.slim
@@ -12,4 +12,4 @@
         table.table
           - @release.devices.each do |device|
             tr
-              td = device
+              td = device.udid

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,7 @@ Rails.application.routes.draw do
     post 'debug_files/upload', to: 'debug_files#create'
     get 'debug_files/download', to: 'debug_files/download#show'
     resources :debug_files, except: %i[create new edit]
+    resources :devices, only: %i[update]
 
     namespace :jenkins do
       get 'projects', to: 'projects#index'

--- a/db/migrate/20140926021348_create_users.rb
+++ b/db/migrate/20140926021348_create_users.rb
@@ -1,6 +1,6 @@
 class CreateUsers < ActiveRecord::Migration[6.0]
   def change
-    create_table(:users) do |t|
+    create_table :users do |t|
       ## Database authenticatable
       t.string :username,           unique: true
       t.string :email,              null: false, default: '', unique: true

--- a/db/migrate/20200523073900_create_devices.rb
+++ b/db/migrate/20200523073900_create_devices.rb
@@ -1,0 +1,10 @@
+class CreateDevices < ActiveRecord::Migration[6.0]
+  def change
+    create_table :devices do |t|
+      t.string :udid, unique: true, null: false, index: true
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200523074639_create_join_table_release_devices.rb
+++ b/db/migrate/20200523074639_create_join_table_release_devices.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableReleaseDevices < ActiveRecord::Migration[6.0]
+  def change
+    create_join_table :releases, :devices do |t|
+      t.index [:release_id, :device_id]#, unique: true
+      t.index [:device_id, :release_id]#, unique: true
+    end
+  end
+end

--- a/db/migrate/20200523081718_rename_table_release_devices_to_old_devices.rb
+++ b/db/migrate/20200523081718_rename_table_release_devices_to_old_devices.rb
@@ -1,0 +1,9 @@
+class RenameTableReleaseDevicesToOldDevices < ActiveRecord::Migration[6.0]
+  def up
+    rename_column :releases, :devices, :legacy_devices
+  end
+
+  def down
+    rename_column :releases, :legacy_devices, :devices
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_08_074228) do
+ActiveRecord::Schema.define(version: 2020_05_23_081718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,21 @@ ActiveRecord::Schema.define(version: 2020_05_08_074228) do
     t.index ["app_id"], name: "index_debug_files_on_app_id"
   end
 
+  create_table "devices", force: :cascade do |t|
+    t.string "udid", null: false
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["udid"], name: "index_devices_on_udid"
+  end
+
+  create_table "devices_releases", id: false, force: :cascade do |t|
+    t.bigint "release_id", null: false
+    t.bigint "device_id", null: false
+    t.index ["device_id", "release_id"], name: "index_devices_releases_on_device_id_and_release_id"
+    t.index ["release_id", "device_id"], name: "index_devices_releases_on_release_id_and_device_id"
+  end
+
   create_table "releases", force: :cascade do |t|
     t.bigint "channel_id"
     t.string "bundle_id", null: false
@@ -93,7 +108,7 @@ ActiveRecord::Schema.define(version: 2020_05_08_074228) do
     t.string "ci_url"
     t.jsonb "changelog", null: false
     t.string "file"
-    t.jsonb "devices", default: [], null: false
+    t.jsonb "legacy_devices", default: [], null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "custom_fields", default: [], null: false

--- a/lib/tasks/zealot/migration.rake
+++ b/lib/tasks/zealot/migration.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+namespace :zealot do
+  namespace :migration do
+    task upgrade: :environment do
+      Rake::Task['zealot:migration:upgrade_devices'].invoke if Device.count.zero? || Device.take.releases.empty?
+    end
+
+    # 把 Release.devices JSON 字符串转移到独立表 Device
+    task upgrade_devices: :environment do
+      puts 'Moving devices data from Release table into Device table'
+
+      udids = []
+      Release.find_each do |release|
+        next if release.legacy_devices.empty?
+
+        release.legacy_devices.each do |udid|
+          udids << udid unless udids.include?(udid)
+
+          device = Device.find_or_create_by!(udid: udid)
+          release.devices << device
+        end
+      end
+
+      puts "Valiting device data"
+      if Device.count == udids.count
+
+      end
+    end
+  end
+end

--- a/lib/tasks/zealot/zealot.rake
+++ b/lib/tasks/zealot/zealot.rake
@@ -14,11 +14,12 @@ namespace :zealot do
   namespace :db do
     task upgrade: :environment do
       begin
-        db_version = Rake::Task['db:version'].invoke.split(': ').last
-        if db_version == '0'
+        db_version = ActiveRecord::Migrator.current_version
+        if db_version == 0
           Rake::Task['zealot:db:setup'].invoke
         else
           Rake::Task['zealot:db:migrate'].invoke
+          Rake::Task['zealot:migration:upgrade'].invoke
         end
       rescue PG::ConnectionBad, ActiveRecord::NoDatabaseError
         # 无法连接数据库


### PR DESCRIPTION
之前上传 iOS AdHoc 版本安装包会把 Profile 里面所有设备 udid 列表存在 Releases 表的 devices 字段，此 PR 主要是把 devices 拆出独立 Devices 表并支持设备名称。

鉴于 Apple 系统的对于账户体系高度安全性，无法在 zealot 系统内集成本功能，经过设计改从 [fastlane-plugin-zealot](https://github.com/getzealot/fastlane-plugin-zealot) 新增 `zealot_sync_device` action 来实现同步。

**fastlane-plugin-zealot** 需要 v0.4.1 版本以上支持本功能。