### PR TITLE
LDAP 登录合并到现有登录界面

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,10 @@
 module ApplicationHelper
   RANDOM_COLORS = %w[aqua blue purple navy maroon yellow red].freeze
 
+  def user_signed_in_or_guest_mode?
+    user_signed_in? || (Setting.guest_mode && !devise_page?)
+  end
+
   def devise_page?
     params[:controller].start_with?('devise/')
   end

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module DeviseHelper
+  def ldap_auth_enable?
+    devise_mapping.omniauthable? && resource_class.oauth_providers.include?(:ldap)
+  end
+end

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -6,17 +6,12 @@
     == render 'devise/shared/intro'
   .login-box.col-sm-5.order-1.order-sm-12
     .card.card-primary.card-outline.card-outline-tabs
+      .card-header.p-0.border-bottom-0
+        ul.nav.nav-tabs role="tablist"
+          == render 'devise/shared/tab_normal'
+          == render 'devise/shared/tab_ldap'
+
       .card-body
-        p.login-box-msg 用户登录
-        = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-          == render 'layouts/messages'
-
-          = f.input :email, required: true, autofocus: true, hint: '', input_html: { autocomplete: "email", class: 'form-control' }
-          = f.input :password, required: true, input_html: { autocomplete: "current-password" }
-          .row
-            .col-8
-              = f.input :remember_me, as: :boolean, wrapper_html: {class: 'icheck-primary', style: 'margin-top: 6px!important'}, label_html: { style: 'font-weight: 700'} if devise_mapping.rememberable?
-            .col-4
-              = f.button :submit, '登录', class: 'btn-block'
-
-        == render 'devise/shared/links'
+        #login-box-tabs.tab-content
+          == render 'devise/shared/form_normal'
+          == render 'devise/shared/form_ldap'

--- a/app/views/devise/shared/_form_ldap.html.slim
+++ b/app/views/devise/shared/_form_ldap.html.slim
@@ -1,0 +1,20 @@
+#login-tabs-ldap.tab-pane.fade aria-labelledby="login-tabs-ldap-tab" role="tabpanel"
+  = form_tag(omniauth_callback_path(:user, :ldap)) do
+    .form-group
+      = label_tag :username, "LDAP 账户"
+      = text_field_tag :username, nil, class: "form-control top", title: "This field is required.", autofocus: "autofocus", data: { qa_selector: 'username_field' }, required: true
+    .form-group
+      = label_tag :password, "LDAP 密码"
+      = password_field_tag :password, nil, class: "form-control bottom", title: "This field is required.", data: { qa_selector: 'password_field' }, required: true
+
+    - if devise_mapping.rememberable?
+      .row
+        .col-12
+          fieldset.form-group.boolean.optional.user_remember_me.icheck-primary style=("margin-top: 6px!important")
+            .form-check
+              = check_box_tag :remember_me, '1', false, id: 'user_remember_me', class: 'form-check-input boolean optional'
+              = label_tag :remember_me, '记住我', class: 'form-check-label boolean optional', style: 'font-weight: 700'
+    .row
+      .col-12
+        = submit_tag "登录", class: "btn btn-primary btn-block", data: { qa_selector: 'sign_in_button' }
+

--- a/app/views/devise/shared/_form_normal.html.slim
+++ b/app/views/devise/shared/_form_normal.html.slim
@@ -1,0 +1,15 @@
+#login-tabs-standard.tab-pane.fade.show.active aria-labelledby="login-tabs-standard-tab" role="tabpanel"
+  = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+    == render 'layouts/messages'
+
+    = f.input :email, required: true, autofocus: true, hint: '', input_html: { autocomplete: "email", class: 'form-control' }
+    = f.input :password, required: true, input_html: { autocomplete: "current-password" }
+
+    .row
+      .col-12
+        = f.input :remember_me, as: :boolean, wrapper_html: {class: 'icheck-primary', style: 'margin-top: 6px!important'}, label_html: { style: 'font-weight: 700'} if devise_mapping.rememberable?
+    .row
+      .col-12
+        = f.button :submit, '登录', class: 'btn-block'
+
+  == render 'devise/shared/links'

--- a/app/views/devise/shared/_links.html.slim
+++ b/app/views/devise/shared/_links.html.slim
@@ -2,12 +2,13 @@
   .social-auth-links.text-center.mb-3
     p - 或者 -
     - resource_class.oauth_providers.each do |provider|
-      ruby:
-        name = omniauth_display_name(provider)
+      - unless provider == :ldap
+        ruby:
+          name = omniauth_display_name(provider)
 
-      a.btn.btn-icon.btn-block href="#{public_send("user_#{provider}_omniauth_authorize_path")}" class="#{provider == :google_oauth2 ? 'btn-danger' : 'btn-default'}"
-        i.fab class="fa-#{name.downcase}"
-        = "使用 #{name} 账号登录"
+        a.btn.btn-icon.btn-block href="#{public_send("user_#{provider}_omniauth_authorize_path")}" class="#{provider == :google_oauth2 ? 'btn-danger' : 'btn-default'}"
+          i.fab class="fa-#{name.downcase}"
+          = "使用 #{name} 账号登录"
 
 - if controller_name != 'sessions'
   p.mb-1

--- a/app/views/devise/shared/_tab_ldap.html.slim
+++ b/app/views/devise/shared/_tab_ldap.html.slim
@@ -1,0 +1,4 @@
+- if ldap_auth_enable?
+  li.nav-item
+    a#login-tabs-ldap-tab.nav-link aria-controls="login-tabs-ldap" aria-selected="true" data-toggle="pill" href="#login-tabs-ldap" role="tab"
+      | LDAP 登录

--- a/app/views/devise/shared/_tab_normal.html.slim
+++ b/app/views/devise/shared/_tab_normal.html.slim
@@ -1,0 +1,3 @@
+li.nav-item
+  a#login-tabs-standard-tab.nav-link.active aria-controls="login-tabs-standard" aria-selected="false" data-toggle="pill" href="#login-tabs-standard" role="tab"
+    | 标准登录

--- a/app/views/layouts/_content.html.slim
+++ b/app/views/layouts/_content.html.slim
@@ -4,5 +4,5 @@
 section.content
   - if user_signed_in?
     == render 'layouts/messages'
-  .container-fluid
+  .container
     == yield

--- a/app/views/layouts/_messages.html.slim
+++ b/app/views/layouts/_messages.html.slim
@@ -1,8 +1,7 @@
-
 - flash.each do |name, msg|
   ruby:
     color, icon = case name
-                  when :notice, :success
+                  when 'notice', 'success'
                     ['success', 'check']
                   else
                     ['danger', 'exclamation-triangle']

--- a/app/views/layouts/_navigation.html.slim
+++ b/app/views/layouts/_navigation.html.slim
@@ -1,6 +1,6 @@
 // Navbar
 nav.main-header.navbar.navbar-expand.navbar-white.navbar-light
-  - if Setting.guest_mode || user_signed_in?
+  - if user_signed_in_or_guest_mode?
     ul.navbar-nav
       li.nav-item
         a.nav-link data-widget="pushmenu" href="#"
@@ -28,8 +28,8 @@ nav.main-header.navbar.navbar-expand.navbar-white.navbar-light
         a href="#{ root_path }" style="color: black" = Setting.site_title
 
 // Main Sidebar Container
-- if Setting.guest_mode || user_signed_in?
-  aside.main-sidebar.sidebar-light-primary.elevation-4
+- if user_signed_in_or_guest_mode?
+  aside.main-sidebar.sidebar-light-primary.elevation-2
     // Brand Logo
     a.brand-link href="#{ root_path }"
       = image_tag asset_pack_path('media/images/touch-icon.png'), class: %w[brand-image]

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,8 +1,8 @@
 ruby:
   body_class = 'skin-black-light'
-  if Setting.guest_mode || user_signed_in?
+  if user_signed_in_or_guest_mode?
     body_class += ' sidebar-mini'
-  elsif devise_page?
+  elsif Setting.guest_mode && devise_page?
     body_class += ' layout-top-nav'
   else
     body_class += ' layout-top-nav'


### PR DESCRIPTION
利用 omniauth-ldap 的 LDAP 是利用一个临时的新页面虽然功能可用但是不统一造成有点怪怪的，先优化到现有登录界面，效果如下：

<img width="516" alt="loginbox-ldap" src="https://user-images.githubusercontent.com/17814/96857980-43310980-1492-11eb-8cec-d60498f28718.png">

目前已知问题：

- [ ] 登录失败时错误信息在标准登录显示
- [ ] 登录失败时无法正确切换到 LDAP 登录标签页