### PR TITLE
Release 4.0.0

### DIFF
--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -6,4 +6,13 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build the Docker image
-      run: docker build --build-arg REPLACE_CHINA_MIRROR=false .
+      uses: elgohr/Publish-Docker-Github-Action@master
+      env:
+        REPLACE_CHINA_MIRROR: false
+        VCS_REF: ${{ github.sha }}
+        BUILD_DATE: ${{ steps.date.outputs.date }}
+        TAG: pr-test
+      with:
+        name: icyleafcn/zealot:${{ env.TAG }}
+        no_push: true
+        buildargs: BUILD_DATE,VCS_REF,TAG,REPLACE_CHINA_MIRROR

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG TAG
 
-ARG ZEALOT_VERSION="4.0.0.rc2"
+ARG ZEALOT_VERSION="4.0.0"
 ARG REPLACE_CHINA_MIRROR="true"
 ARG ORIGINAL_REPO_URL="http://dl-cdn.alpinelinux.org"
 ARG MIRROR_REPO_URL="https://mirrors.tuna.tsinghua.edu.cn"


### PR DESCRIPTION
2020 年初历经多年的内部系统以全新的名字 zealot 公开发布了全新的 4.0.0 beta 版本，经过一年内部使用和功能翻新，发布了 4 个 beta 版本，2 个 rc 版本的今天自认为可以拿的出手，现在宣布 4.0.0 发布了！

### 修复

- [Web] 修正文件解析 iOS 证书对失效时间判断异常造成的页面错误显示
- [Web] 忽略默认开发版本号检查新版本

> 代码变更历史：[4.0.0]

[4.0.0]: https://github.com/getzealot/zealot/compare/4.0.0.rc2...edca6247214ed4d650fe0efd4828d6d93b574e82